### PR TITLE
Handle extra punctuation symbol after CHANGELOG description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#17](https://github.com/dblock/danger-changelog/pull/17): Fix: handle CHANGELOG lines that mistakenly start with a symbol other than * - [@antondomashnev](https://github.com/antondomashnev).
 * [#19](https://github.com/dblock/danger-changelog/pull/19): Added: RELEASING.md document to formalize the process - [@antondomashnev](https://github.com/antondomashnev).
+* [#20](https://github.com/dblock/danger-changelog/pull/20): Fix: flag extra punctuation symbol in the CHANGELOG after change description - [@antondomashnev](https://github.com/antondomashnev).
 * Your contribution here.
 
 ### 0.2.0 (11/21/2016)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * [#17](https://github.com/dblock/danger-changelog/pull/17): Fix: handle CHANGELOG lines that mistakenly start with a symbol other than * - [@antondomashnev](https://github.com/antondomashnev).
 * [#19](https://github.com/dblock/danger-changelog/pull/19): Added: RELEASING.md document to formalize the process - [@antondomashnev](https://github.com/antondomashnev).
-* [#20](https://github.com/dblock/danger-changelog/pull/20): Fix: flag extra punctuation symbol in the CHANGELOG after change description - [@antondomashnev](https://github.com/antondomashnev).
+* [#20](https://github.com/dblock/danger-changelog/pull/20): Fix: flag extra period and column in CHANGELOG - [@antondomashnev](https://github.com/antondomashnev).
 * Your contribution here.
 
 ### 0.2.0 (11/21/2016)

--- a/lib/changelog/changelog_line/changelog_entry_line.rb
+++ b/lib/changelog/changelog_line/changelog_entry_line.rb
@@ -5,8 +5,8 @@ module Danger
     # A CHANGELOG.md line represents the change entry.
     class ChangelogEntryLine < ChangelogLine
       def valid?
-        return true if line =~ %r{^\*\s[\`[:upper:]].* \- \[\@[\w\d\-\_]+\]\(https:\/\/github\.com\/.*[\w\d\-\_]+\).$}
-        return true if line =~ %r{^\*\s\[\#\d+\]\(https:\/\/github\.com\/.*\d+\)\: [\`[:upper:]].* \- \[\@[\w\d\-\_]+\]\(https:\/\/github\.com\/.*[\w\d\-\_]+\).$}
+        return true if line =~ %r{^\*\s[\`[:upper:]].*[^\[[:punct:]\]] \- \[\@[\w\d\-\_]+\]\(https:\/\/github\.com\/.*[\w\d\-\_]+\).$}
+        return true if line =~ %r{^\*\s\[\#\d+\]\(https:\/\/github\.com\/.*\d+\)\: [\`[:upper:]].*[^\[[:punct:]\]] \- \[\@[\w\d\-\_]+\]\(https:\/\/github\.com\/.*[\w\d\-\_]+\).$}
         false
       end
 

--- a/lib/changelog/changelog_line/changelog_entry_line.rb
+++ b/lib/changelog/changelog_line/changelog_entry_line.rb
@@ -5,8 +5,8 @@ module Danger
     # A CHANGELOG.md line represents the change entry.
     class ChangelogEntryLine < ChangelogLine
       def valid?
-        return true if line =~ %r{^\*\s[\`[:upper:]].*[^\[[:punct:]\]] \- \[\@[\w\d\-\_]+\]\(https:\/\/github\.com\/.*[\w\d\-\_]+\).$}
-        return true if line =~ %r{^\*\s\[\#\d+\]\(https:\/\/github\.com\/.*\d+\)\: [\`[:upper:]].*[^\[[:punct:]\]] \- \[\@[\w\d\-\_]+\]\(https:\/\/github\.com\/.*[\w\d\-\_]+\).$}
+        return true if line =~ %r{^\*\s[\`[:upper:]].*[^.,] \- \[\@[\w\d\-\_]+\]\(https:\/\/github\.com\/.*[\w\d\-\_]+\).$}
+        return true if line =~ %r{^\*\s\[\#\d+\]\(https:\/\/github\.com\/.*\d+\)\: [\`[:upper:]].*[^.,] \- \[\@[\w\d\-\_]+\]\(https:\/\/github\.com\/.*[\w\d\-\_]+\).$}
         false
       end
 

--- a/spec/changelog_entry_line_spec.rb
+++ b/spec/changelog_entry_line_spec.rb
@@ -98,6 +98,38 @@ describe Danger::Changelog::ChangelogEntryLine do
       end
     end
 
+    context 'when extra period' do
+      subject { Danger::Changelog::ChangelogEntryLine.new('* [#1](https://github.com/dblock/danger-changelog/pull/1): Extra period. - [@dblock](https://github.com/dblock).') }
+
+      it 'is invalid' do
+        expect(subject.invalid?).to be true
+      end
+    end
+
+    context 'when extra colon' do
+      subject { Danger::Changelog::ChangelogEntryLine.new('* [#1](https://github.com/dblock/danger-changelog/pull/1): Extra colon, - [@dblock](https://github.com/dblock).') }
+
+      it 'is invalid' do
+        expect(subject.invalid?).to be true
+      end
+    end
+
+    context 'when extra hash' do
+      subject { Danger::Changelog::ChangelogEntryLine.new('* [#1](https://github.com/dblock/danger-changelog/pull/1): With # - [@dblock](https://github.com/dblock).') }
+
+      it 'is valid' do
+        expect(subject.valid?).to be true
+      end
+    end
+
+    context 'when with question mark' do
+      subject { Danger::Changelog::ChangelogEntryLine.new('* [#1](https://github.com/dblock/danger-changelog/pull/1): With ? - [@dblock](https://github.com/dblock).') }
+
+      it 'is valid' do
+        expect(subject.valid?).to be true
+      end
+    end
+
     context 'when hash instead of star' do
       subject { Danger::Changelog::ChangelogEntryLine.new('# [#1](https://github.com/dblock/danger-changelog/pull/1): Hash instead of star - [@dblock](https://github.com/dblock).') }
 

--- a/spec/changelog_file_spec.rb
+++ b/spec/changelog_file_spec.rb
@@ -50,7 +50,8 @@ describe Danger::Changelog::ChangelogFile do
         "Missing star - [@dblock](https://github.com/dblock).\n",
         "* [#1](https://github.com/dblock/danger-changelog/pull/1) - Not a colon - [@dblock](https://github.com/dblock).\n",
         "* [#1](https://github.com/dblock/danger-changelog/pull/1): No final period - [@dblock](https://github.com/dblock)\n",
-        "# [#1](https://github.com/dblock/danger-changelog/pull/1): Hash instead of star - [@dblock](https://github.com/dblock).\n"
+        "# [#1](https://github.com/dblock/danger-changelog/pull/1): Hash instead of star - [@dblock](https://github.com/dblock).\n",
+        "* [#1](https://github.com/dblock/danger-changelog/pull/1): Extra period. - [@dblock](https://github.com/dblock).\n"
       ]
     end
     it 'has your contribution here' do

--- a/spec/changelog_spec.rb
+++ b/spec/changelog_spec.rb
@@ -131,7 +131,8 @@ describe Danger::Changelog do
                 "```markdown\nMissing star - [@dblock](https://github.com/dblock).\n```\n",
                 "```markdown\n* [#1](https://github.com/dblock/danger-changelog/pull/1) - Not a colon - [@dblock](https://github.com/dblock).\n```\n",
                 "```markdown\n* [#1](https://github.com/dblock/danger-changelog/pull/1): No final period - [@dblock](https://github.com/dblock)\n```\n",
-                "```markdown\n# [#1](https://github.com/dblock/danger-changelog/pull/1): Hash instead of star - [@dblock](https://github.com/dblock).\n```\n"
+                "```markdown\n# [#1](https://github.com/dblock/danger-changelog/pull/1): Hash instead of star - [@dblock](https://github.com/dblock).\n```\n",
+                "```markdown\n* [#1](https://github.com/dblock/danger-changelog/pull/1): Extra period. - [@dblock](https://github.com/dblock).\n```\n"
               ]
             end
           end

--- a/spec/fixtures/changelogs/with_bad_lines.md
+++ b/spec/fixtures/changelogs/with_bad_lines.md
@@ -4,4 +4,5 @@ Missing star - [@dblock](https://github.com/dblock).
 * [#1](https://github.com/dblock/danger-changelog/pull/1) - Not a colon - [@dblock](https://github.com/dblock).
 * [#1](https://github.com/dblock/danger-changelog/pull/1): No final period - [@dblock](https://github.com/dblock)
 # [#1](https://github.com/dblock/danger-changelog/pull/1): Hash instead of star - [@dblock](https://github.com/dblock).
+* [#1](https://github.com/dblock/danger-changelog/pull/1): Extra period. - [@dblock](https://github.com/dblock).
 * Your contribution here.


### PR DESCRIPTION
This is fixing the #15. I've also let the danger handle not only the `,`, but all punctuation symbol because they are not expected there. 