### PR TITLE
Fix typo

### DIFF
--- a/lib/changelog/plugin.rb
+++ b/lib/changelog/plugin.rb
@@ -83,7 +83,7 @@ module Danger
         messaging.fail(parser.bad_line_message(filename), sticky: false) if changelog_file.bad_lines?
 
         changelog_file.global_failures.each do |failure|
-          messaging.fail(failure, sticy: false)
+          messaging.fail(failure, sticky: false)
         end
 
         changelog_file.good?


### PR DESCRIPTION
Just noticed this – I guess it doesn't make a difference for what is happening as `false` is the default value. Feel free to ignore, just thought I'd let you know. :)