### PR TITLE
Fix: report on lines that start with a - and cannot be parsed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 0.7.1 (Next)
 
+* [#63](https://github.com/dblock/danger-changelog/pull/63): Fix: report on lines that start with a - and cannot be parsed - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ### 0.7.0 (2023/11/21)

--- a/lib/changelog/parsers/intridea_format.rb
+++ b/lib/changelog/parsers/intridea_format.rb
@@ -17,7 +17,10 @@ module Danger
 
             changelog_line = ChangelogLineParser.parse(line)
 
-            if changelog_line.nil? || changelog_line.invalid?
+            if changelog_line.nil?
+              notify_of_bad_line line, 'cannot be parsed'
+              next
+            elsif changelog_line.invalid?
               detail = changelog_line.validation_result.to_s if changelog_line.validation_result&.invalid?
               notify_of_bad_line line, detail
               next

--- a/spec/intridea/changelog_spec.rb
+++ b/spec/intridea/changelog_spec.rb
@@ -143,6 +143,20 @@ describe Danger::Changelog do
               ]
             end
           end
+
+          context 'with a contribution line starting with a -' do
+            let(:filename) { File.expand_path('fixtures/validation_result.md', __dir__) }
+            it 'cannot be parsed' do
+              expect(subject).to be false
+              expect(status_report[:errors]).to eq ["One of the lines below found in #{filename} doesn't match the [expected format](https://github.com/dblock/danger-changelog/blob/master/README.md#whats-a-correctly-formatted-changelog-file). Please make it look like the other lines, pay attention to version numbers, periods, spaces and date formats."]
+              expect(status_report[:warnings]).to eq []
+              expect(status_report[:markdowns].map(&:message)).to eq [
+                "```markdown\n- [#67](https://github.com/dblock/danger-changelog/pull/67): Various build updates - [@bob](https://github.com/bob).\ndoes not start with a star\n```\n",
+                "```markdown\n- [#68](https://github.com/dblock/danger-changelog/pull/68): Properly render `example` - [@janet](https://github.com/janet).\ndoes not start with a star\n```\n",
+                "```markdown\n- Your contribution here.\ncannot be parsed\n```\n"
+              ]
+            end
+          end
         end
       end
     end

--- a/spec/intridea/fixtures/validation_result.md
+++ b/spec/intridea/fixtures/validation_result.md
@@ -1,0 +1,6 @@
+### Next
+#### Fixes
+- [#67](https://github.com/dblock/danger-changelog/pull/67): Various build updates - [@bob](https://github.com/bob).
+- [#68](https://github.com/dblock/danger-changelog/pull/68): Properly render `example` - [@janet](https://github.com/janet).
+- Your contribution here.
+* Your contribution here.


### PR DESCRIPTION
Error from https://github.com/ruby-grape/grape-swagger-entity/pull/68. There's a line starting with `-` that cannot be parsed.