### PR TITLE
Migrate to danger-pr-comment workflow pattern

### DIFF
--- a/.github/workflows/danger-comment.yml
+++ b/.github/workflows/danger-comment.yml
@@ -6,5 +6,5 @@ on:
 
 jobs:
   comment:
-    uses: ruby-grape/danger/.github/workflows/danger-comment.yml@master
+    uses: numbata/danger-pr-comment/.github/workflows/danger-comment.yml@v0.1.0
     secrets: inherit

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -5,5 +5,8 @@ on:
 
 jobs:
   danger:
-    uses: ruby-grape/danger/.github/workflows/danger-run.yml@master
+    uses: numbata/danger-pr-comment/.github/workflows/danger-run.yml@v0.1.0
     secrets: inherit
+    with:
+      ruby-version: '3.4'
+      bundler-cache: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 0.8.1 (Next)
 
+* [#71](https://github.com/dblock/danger-changelog/pull/71): Migrate to danger-pr-comment workflow pattern - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ### 0.8.0 (2025/12/18)

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,4 +1,6 @@
-# danger.systems
+# frozen_string_literal: true
 
-# Import ruby-grape-danger for automatic danger report export
-danger.import_dangerfile(gem: 'ruby-grape-danger')
+danger.import_dangerfile(gem: 'danger-pr-comment')
+
+changelog.check!
+toc.check!

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ gemspec
 group :development, :test do
   gem 'activesupport'
   gem 'bundler'
+  gem 'danger'
+  gem 'danger-pr-comment', '~> 0.1.0'
   gem 'danger-toc', '~> 0.2.0'
   gem 'guard', '~> 2.14'
   gem 'guard-rspec', '~> 4.7'
@@ -15,6 +17,5 @@ group :development, :test do
   gem 'rubocop', '~> 1.63.1'
   gem 'rubocop-rake'
   gem 'rubocop-rspec'
-  gem 'ruby-grape-danger'
   gem 'yard', '~> 0.9.11'
 end


### PR DESCRIPTION
## Summary
- Replace ruby-grape-danger with danger-pr-comment gem v0.1.0
- Update workflows to use numbata/danger-pr-comment reusable workflows
- Add direct changelog.check! and toc.check! calls in Dangerfile

## Test plan
- [ ] Verify Danger workflows run successfully on this PR
- [ ] Confirm changelog and TOC checks work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)